### PR TITLE
Add persistence to each view

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -40,7 +40,7 @@ jspm_packages
 /coverage
 
 # production
-/build
+ui/build
 
 # misc
 .DS_Store

--- a/Dockerfile
+++ b/Dockerfile
@@ -5,10 +5,10 @@ RUN apt-get install nginx -y
 
 RUN npm install -g serve
 
-# Create api and ui directory
+# Create directories
 RUN mkdir -p /root/sqlwidget/api
 RUN mkdir -p /root/sqlwidget/ui
-
+RUN mkdir -p /opt/sqlwidget/
 
 # Install app dependencies
 COPY api/package.json /root/sqlwidget/api

--- a/api/app.js
+++ b/api/app.js
@@ -32,7 +32,7 @@ app.use(bodyParser.urlencoded({ extended: false }));
 
 app.use(function(req,res,next) {
     req.db = db;
-    req.query = Promise.promisify(db.query, {context: db});
+    req.querydb = Promise.promisify(db.query, {context: db});
     next();
 });
 

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -14,3 +14,5 @@ services:
       - db
     links:
       - db
+    volumes:
+      - /workspace/history:/opt/sqlwidget

--- a/nginx/nginx.conf
+++ b/nginx/nginx.conf
@@ -15,7 +15,7 @@ http {
         }
 
         location / {
-          return 301 /sql/ui/;
+            return 302 " /sql/ui/";
         }
     }
 }

--- a/ui/package.json
+++ b/ui/package.json
@@ -5,6 +5,7 @@
   "homepage": ".",
   "dependencies": {
     "axios": "^0.16.1",
+    "lodash": "^4.17.4",
     "react": "^15.5.4",
     "react-codemirror": "^0.3.0",
     "react-dom": "^15.5.4"

--- a/ui/src/index.js
+++ b/ui/src/index.js
@@ -13,6 +13,6 @@ function getParameterByName(name, url) {
 }
 
 ReactDOM.render(
-  <App query={getParameterByName("q")} useHeader={getParameterByName("h")}/>,
+  <App query={getParameterByName("q")} useHeader={getParameterByName("h")} viewId={getParameterByName("viewId")}/>,
   document.getElementById('root')
 );


### PR DESCRIPTION
The window will remember the last query entered.  The backend is keeping
track of up to 20 queries per view, but only the most recent is expsed
in this commit.

The configuration is saved in a simple JSON file.